### PR TITLE
Fix Edit mode improvements

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
     
     steps:
     - uses: actions/checkout@v4
@@ -83,7 +83,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
     
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
     
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "thonny-codemate"
-version = "0.1.5"
+version = "0.1.6"
 description = "A Thonny IDE plugin that provides AI-powered coding assistance using local and cloud LLMs"
 readme = "README.md"
 authors = [
@@ -20,6 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Education",
     "Topic :: Software Development :: Code Generators",
 ]

--- a/tests/test_edit_mode_handler.py
+++ b/tests/test_edit_mode_handler.py
@@ -135,7 +135,6 @@ def create_markdown():
     
     def test_extract_code_block_indented(self):
         """Test extraction with indented code blocks"""
-        # Regex now requires fence to be at start of line (with optional whitespace)
         response = """The solution:
 ```python
 def solve():

--- a/tests/test_edit_mode_handler.py
+++ b/tests/test_edit_mode_handler.py
@@ -1,0 +1,127 @@
+"""
+Tests for EditModeHandler
+"""
+import pytest
+from thonnycontrib.thonny_codemate.edit_mode_handler import EditModeHandler
+
+
+class TestEditModeHandler:
+    def setup_method(self):
+        """Set up test fixtures"""
+        self.handler = EditModeHandler(llm_client=None)
+    
+    def test_extract_code_block_simple(self):
+        """Test simple code block extraction"""
+        response = """Here's the updated code:
+```python
+def hello():
+    print("Hello, world!")
+```
+"""
+        result = self.handler.extract_code_block(response)
+        assert result == 'def hello():\n    print("Hello, world!")'
+    
+    def test_extract_code_block_with_multiline_string(self):
+        """Test code block extraction with multiline strings containing backticks"""
+        response = """Here's the updated code:
+```python
+def get_help():
+    '''
+    This function returns help text.
+    
+    Usage example:
+    ```
+    result = get_help()
+    print(result)
+    ```
+    '''
+    return "Help text"
+```
+"""
+        result = self.handler.extract_code_block(response)
+        expected = '''def get_help():
+    \'\'\'
+    This function returns help text.
+    
+    Usage example:
+    ```
+    result = get_help()
+    print(result)
+    ```
+    \'\'\'
+    return "Help text"'''
+        assert result == expected
+    
+    def test_extract_code_block_with_triple_quotes(self):
+        """Test code block extraction with triple quotes"""
+        response = '''Here's the code:
+```python
+def format_code():
+    """Format code with markdown."""
+    template = """
+    ```python
+    # Your code here
+    ```
+    """
+    return template
+```
+'''
+        result = self.handler.extract_code_block(response)
+        assert 'def format_code():' in result
+        assert 'template = """' in result
+        assert '# Your code here' in result
+    
+    def test_extract_code_block_no_language(self):
+        """Test code block without language specifier"""
+        response = """Updated:
+```
+x = 10
+y = 20
+```
+"""
+        result = self.handler.extract_code_block(response)
+        assert result == 'x = 10\ny = 20'
+    
+    def test_extract_code_block_no_backticks(self):
+        """Test extraction when no code block markers present"""
+        response = """def calculate(x, y):
+    return x + y
+
+result = calculate(5, 3)"""
+        result = self.handler.extract_code_block(response)
+        assert result == response.strip()
+    
+    def test_build_edit_prompt(self):
+        """Test edit prompt building"""
+        prompt = self.handler.build_edit_prompt(
+            user_prompt="Add error handling",
+            filename="test.py",
+            content="def divide(a, b):\n    return a / b",
+            selection=None
+        )
+        assert "Add error handling" in prompt
+        assert "test.py" in prompt
+        assert "def divide(a, b):" in prompt
+    
+    def test_expand_existing_code_markers(self):
+        """Test expanding ...existing code... markers"""
+        original = """def func1():
+    pass
+
+def func2():
+    pass
+
+def func3():
+    pass"""
+        
+        modified = """def func1():
+    pass
+
+# ...existing code...
+
+def func3():
+    print("Modified")"""
+        
+        result = self.handler.expand_existing_code_markers(modified, original)
+        assert "def func2():" in result
+        assert 'print("Modified")' in result

--- a/tests/test_edit_mode_handler.py
+++ b/tests/test_edit_mode_handler.py
@@ -103,6 +103,88 @@ result = calculate(5, 3)"""
         assert "test.py" in prompt
         assert "def divide(a, b):" in prompt
     
+    def test_extract_code_block_with_standalone_backticks(self):
+        """Test extraction when code contains standalone triple backticks"""
+        response = '''Here's the code:
+```python
+def create_markdown():
+    content = """
+```
+"""
+    return content
+```
+'''
+        result = self.handler.extract_code_block(response)
+        assert 'def create_markdown():' in result
+        assert 'content = """' in result
+        # The standalone ``` should be included as part of the code
+        assert '```' in result.split('content = """')[1]
+    
+    def test_extract_code_block_indented(self):
+        """Test extraction with indented code blocks"""
+        response = """The solution:
+    ```python
+    def solve():
+        return 42
+    ```
+"""
+        result = self.handler.extract_code_block(response)
+        assert result == 'def solve():\n    return 42'
+    
+    def test_extract_code_block_deeply_nested_backticks(self):
+        """Test with deeply nested backticks in strings"""
+        response = '''Updated code:
+```python
+def markdown_example():
+    """
+    Example:
+    ```python
+    result = process()
+    ```
+    """
+    template = f"""
+    # Title
+    ```
+    code here
+    ```
+    """
+    return template
+```
+End of code.'''
+        result = self.handler.extract_code_block(response)
+        assert 'def markdown_example():' in result
+        assert 'template = f"""' in result
+        assert result.count('```') >= 2  # Should contain the backticks in the strings
+    
+    def test_extract_code_block_with_different_fence_lengths(self):
+        """Test extraction with different fence lengths (VSCode style)"""
+        response = '''Here's the updated code:
+````python
+def example():
+    markdown = """
+    ```python
+    code example
+    ```
+    """
+    return markdown
+````
+'''
+        result = self.handler.extract_code_block(response)
+        assert 'def example():' in result
+        assert '```python' in result  # Inner fence should be preserved
+        assert 'code example' in result
+    
+    def test_extract_code_block_with_tilde_fences(self):
+        """Test extraction with tilde fences"""
+        response = """Code below:
+~~~python
+def test():
+    return True
+~~~
+"""
+        result = self.handler.extract_code_block(response)
+        assert result == 'def test():\n    return True'
+    
     def test_expand_existing_code_markers(self):
         """Test expanding ...existing code... markers"""
         original = """def func1():

--- a/thonnycontrib/thonny_codemate/__init__.py
+++ b/thonnycontrib/thonny_codemate/__init__.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 logger.disabled = True
 
 # プラグインのバージョン
-__version__ = "0.1.5"
+__version__ = "0.1.6"
 
 # グローバル変数でプラグインの状態を管理
 _plugin_loaded = False

--- a/thonnycontrib/thonny_codemate/ui/chat_view_html.py
+++ b/thonnycontrib/thonny_codemate/ui/chat_view_html.py
@@ -1290,9 +1290,9 @@ Full file content:
         text_widget = editor.get_text_widget()
         content = text_widget.get("1.0", tk.END).strip()
         
+        # 空のファイルでも処理を続行（新規コード生成として扱う）
         if not content:
-            self._add_message("system", tr("The editor is empty. Please write some code first."))
-            return
+            content = ""  # 空のコンテンツとして処理
         
         # 選択範囲を取得（あれば）
         selection_info = self.edit_mode_handler.get_selection_info(editor)


### PR DESCRIPTION
## Summary
- Add stop generation support for Edit mode
- Fix Edit mode termination with multiline strings
- Implement VSCode-style robust code block extraction

## Changes
1. **Stop Generation Support**
   - Enable Stop button during Edit mode generation
   - Prevent code changes from being applied if generation was stopped

2. **Multiline String Handling**
   - Replace regex-based extraction with line-by-line parsing
   - Properly handle triple backticks inside Python multiline strings

3. **VSCode-Style Code Block Extraction**
   - Support different fence lengths (e.g., ```` for blocks containing ```)
   - Support tilde fences (~) as alternative to backticks
   - Closing fence must match opening fence type and length
   - Add comprehensive test cases for edge cases

## Test Plan
- [x] Manual testing with various code examples
- [ ] GitHub Actions CI tests
- [x] Added unit tests for edge cases